### PR TITLE
fix: remove unnecessary explicit role

### DIFF
--- a/packages/react/src/components/Nav/Nav.base.tsx
+++ b/packages/react/src/components/Nav/Nav.base.tsx
@@ -69,7 +69,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
     return (
       <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone} {...this.props.focusZoneProps}>
-        <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
+        <nav className={classNames.root} aria-label={this.props.ariaLabel}>
           {groupElements}
         </nav>
       </FocusZone>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Current Behavior

An unnecessary explicit `role="navigation"` is added to `nav` element.
The `role="navigation"` is an implicit role based on the ARIA spec:
![image](https://user-images.githubusercontent.com/12711091/178504341-66c007dd-4f64-46aa-9fec-ca94be976c71.png)
https://www.w3.org/TR/2021/REC-html-aria-20211209/#att-min

## New Behavior

I removed the unnecessary explicit role.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
